### PR TITLE
chore: update copyright header

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@loopback/example-shopping",
+  "name": "loopback4-example-shopping",
   "version": "1.0.0",
   "description": "LoopBack 4 Example: Online Shopping APIs",
   "keywords": [

--- a/recommender.js
+++ b/recommender.js
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/recommender/index.ts
+++ b/recommender/index.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/recommender/mock-recommendation-app.ts
+++ b/recommender/mock-recommendation-app.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/src/application.ts
+++ b/src/application.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/src/authentication-strategies/JWT.strategy.ts
+++ b/src/authentication-strategies/JWT.strategy.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2018, 2019. All Rights Reserved.
-// Node module: @loopback4-example-shopping
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/src/authentication-strategies/authentication.strategy.ts
+++ b/src/authentication-strategies/authentication.strategy.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2018, 2019. All Rights Reserved.
-// Node module: @loopback4-example-shopping
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/src/controllers/ping.controller.ts
+++ b/src/controllers/ping.controller.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/src/controllers/shopping-cart.controller.ts
+++ b/src/controllers/shopping-cart.controller.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/src/controllers/user-order.controller.ts
+++ b/src/controllers/user-order.controller.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/src/datasources/index.ts
+++ b/src/datasources/index.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/src/datasources/mongo.datasource.ts
+++ b/src/datasources/mongo.datasource.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/src/datasources/recommender.datasource.ts
+++ b/src/datasources/recommender.datasource.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/src/datasources/redis.datasource.ts
+++ b/src/datasources/redis.datasource.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: loopback4-example-shopping
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {BindingKey} from '@loopback/context';
 import {JWTAuthenticationService} from './services/JWT.authentication.service';
 import {JWTStrategy} from './authentication-strategies/JWT.strategy';

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/src/models/order.model.ts
+++ b/src/models/order.model.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/src/models/product.model.ts
+++ b/src/models/product.model.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: loopback4-example-shopping
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {Entity, model, property} from '@loopback/repository';
 
 @model()

--- a/src/models/shopping-cart-item.model.ts
+++ b/src/models/shopping-cart-item.model.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/src/models/shopping-cart.model.ts
+++ b/src/models/shopping-cart.model.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/src/models/user.model.ts
+++ b/src/models/user.model.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/src/providers/custom.authentication.provider.ts
+++ b/src/providers/custom.authentication.provider.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
-// Node module: @loopback/authentication
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2018, 2019. All Rights Reserved.
-// Node module: @loopback4-example-shopping
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/src/providers/strategy.resolver.provider.ts
+++ b/src/providers/strategy.resolver.provider.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback4-example-shopping
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/src/repositories/index.ts
+++ b/src/repositories/index.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/src/repositories/order.repository.ts
+++ b/src/repositories/order.repository.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/src/repositories/shopping-cart.repository.ts
+++ b/src/repositories/shopping-cart.repository.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/src/repositories/user.repository.ts
+++ b/src/repositories/user.repository.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/src/sequence.ts
+++ b/src/sequence.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/src/services/JWT.authentication.service.ts
+++ b/src/services/JWT.authentication.service.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2018, 2019. All Rights Reserved.
-// Node module: @loopback4-example-shopping
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/src/services/hash.password.bcryptjs.ts
+++ b/src/services/hash.password.bcryptjs.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: loopback4-example-shopping
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {genSalt, hash} from 'bcryptjs';
 import {compare} from 'bcryptjs';
 import {inject} from '@loopback/core';

--- a/src/services/recommender.service.ts
+++ b/src/services/recommender.service.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/test/acceptance/helper.ts
+++ b/test/acceptance/helper.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2018, 2019. All Rights Reserved.
-// Node module: @loopback4-example-shopping
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/test/acceptance/home-page.acceptance.ts
+++ b/test/acceptance/home-page.acceptance.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/test/acceptance/ping.controller.acceptance.ts
+++ b/test/acceptance/ping.controller.acceptance.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/test/acceptance/shopping-cart.controller.acceptance.ts
+++ b/test/acceptance/shopping-cart.controller.acceptance.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/test/acceptance/user-order.controller.acceptance.ts
+++ b/test/acceptance/user-order.controller.acceptance.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/test/acceptance/user.controller.acceptance.ts
+++ b/test/acceptance/user.controller.acceptance.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/test/integration/shopping-cart.repository.integration.ts
+++ b/test/integration/shopping-cart.repository.integration.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/test/unit/helper.ts
+++ b/test/unit/helper.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2018, 2019. All Rights Reserved.
-// Node module: @loopback4-example-shopping
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/test/unit/utils.authentication.unit.ts
+++ b/test/unit/utils.authentication.unit.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2019. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/test/unit/utils.retry.unit.ts
+++ b/test/unit/utils.retry.unit.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2018. All Rights Reserved.
-// Node module: @loopback/example-shopping
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 


### PR DESCRIPTION
Changes in this PR include:
- change the `name` in package.json from `@loopback/example-shopping` to `loopback4-example-shopping` 
- the rest of the changes are generated by running `slt copyright` command.
   - update the "module name" to match with the name in the package.json
   - update the year accordingly.  

FYI - the copyright year is in the format of <year1, year2>, where `year1` is the year that the file was created, `year2` is the year that the file was last touched.