### PR TITLE
ci: disable builds of Renovate branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,3 @@ matrix:
 branches:
   only:
     - master
-    - /^renovate/.*$/


### PR DESCRIPTION
We run the CI for pull requests, no need to run them again for branches.

At the moment, we run Travis CI twice for each PR, which slows down the process significantly.