### PR TITLE
fix: error handling in Sequence

### DIFF
--- a/packages/shopping/src/sequence.ts
+++ b/packages/shopping/src/sequence.ts
@@ -13,7 +13,6 @@ import {
   RestBindings,
   Send,
   SequenceHandler,
-  HttpErrors,
 } from '@loopback/rest';
 import {
   AuthenticationBindings,
@@ -41,6 +40,14 @@ export class MyAuthenticationSequence implements SequenceHandler {
       const {request, response} = context;
       const route = this.findRoute(request);
 
+      //call authentication action
+      await this.authenticateRequest(request);
+
+      // Authentication successful, proceed to invoke controller
+      const args = await this.parseParams(request, route);
+      const result = await this.invoke(route, args);
+      this.send(response, result);
+    } catch (error) {
       //
       // The authentication action utilizes a strategy resolver to find
       // an authentication strategy by name, and then it calls
@@ -52,33 +59,23 @@ export class MyAuthenticationSequence implements SequenceHandler {
       // is expected to return a user profile. If the user profile
       // is undefined, then it throws a non-http error.
       //
-      // It is necessary to catch these errors
-      // and rethrow them as http errors
+      // It is necessary to catch these errors and add HTTP-specific status
+      // code property.
       //
-      // Errors thrown by the strategy implementations are http errors.
-      // We simply rethrow them.
+      // Errors thrown by the strategy implementations already come
+      // with statusCode set.
       //
-      try {
-        //call authentication action
-        await this.authenticateRequest(request);
-      } catch (e) {
-        // strategy not found error, or user profile undefined
-        if (
-          e.code === AUTHENTICATION_STRATEGY_NOT_FOUND ||
-          e.code === USER_PROFILE_NOT_FOUND
-        ) {
-          throw new HttpErrors.Unauthorized(e.message);
-        } else {
-          // strategy error
-          throw e;
-        }
+      // In the future, we want to improve `@loopback/rest` to provide
+      // an extension point allowing `@loopback/authentication` to contribute
+      // mappings from error codes to HTTP status codes, so that application
+      // don't have to map codes themselves.
+      if (
+        error.code === AUTHENTICATION_STRATEGY_NOT_FOUND ||
+        error.code === USER_PROFILE_NOT_FOUND
+      ) {
+        Object.assign(error, {statusCode: 401 /* Unauthorized */});
       }
 
-      // Authentication successful, proceed to invoke controller
-      const args = await this.parseParams(request, route);
-      const result = await this.invoke(route, args);
-      this.send(response, result);
-    } catch (error) {
       this.reject(context, error);
       return;
     }


### PR DESCRIPTION
Rework the code handling authentication errors to correctly preserve stack trace of the original error, instead of creating a new error instance with a stack pointing to the Sequence class only.