### PR TITLE
chore: remove bajtos from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,4 @@
 #
 # See https://help.github.com/articles/about-codeowners/
 
-* @bajtos @raymondfeng @jannyHou @emonddr
+* @raymondfeng @jannyHou @emonddr


### PR DESCRIPTION
I'd like to remove myself from CODEOWNERS. I am already spending quite a lot of time in reviewing pull requests to loopback-next and would like somebody else to take ownership of this example repository.

This is a follow-up for https://github.com/strongloop/loopback4-example-shopping/pull/146