### PR TITLE
Add Node.js 12 for MacOS & Linux and remove Node.js 8 & 10 on MacOS on Travis 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
   - '8'
   - '10'
+  - '12'
 
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ node_js:
 
 os:
   - linux
-  - osx
 
 before_script: ./bin/travis.sh
 script: npm run test:ci
@@ -19,6 +18,10 @@ services:
 
 matrix:
   include:
+    - node_js: "12"
+      os: osx
+      # using the default script to build & run the tests
+
     - node_js: '8'
       os: linux
       env: TASK=code-lint


### PR DESCRIPTION
As discussed in https://github.com/strongloop/loopback-next/pull/3105: We don't have any platform specific code, I think it's enough to pick a single Node.js version to test on MacOS. We test different Node.js versions on Linux.