### PR TITLE
Fix openapi schema

### DIFF
--- a/packages/shopping/src/controllers/ping.controller.ts
+++ b/packages/shopping/src/controllers/ping.controller.ts
@@ -21,8 +21,8 @@ const PING_RESPONSE: ResponseObject = {
           url: {type: 'string'},
           headers: {
             type: 'object',
-            patternProperties: {
-              '^.*$': {type: 'string'},
+            properties: {
+              'Content-Type': {type: 'string'},
             },
             additionalProperties: false,
           },

--- a/packages/shopping/src/controllers/shopping-cart.controller.ts
+++ b/packages/shopping/src/controllers/shopping-cart.controller.ts
@@ -32,11 +32,17 @@ export class ShoppingCartController {
    * @param userId User id
    * @param cart Shopping cart
    */
-  @put('/shoppingCarts/{userId}')
+  @put('/shoppingCarts/{userId}', {
+    responses: {
+      '204': {
+        description: 'User shopping cart is created or updated',
+      },
+    },
+  })
   async set(
     @param.path.string('userId') userId: string,
     @requestBody({description: 'shopping cart'}) cart: ShoppingCart,
-  ) {
+  ): Promise<void> {
     debug('Create shopping cart %s: %j', userId, cart);
     if (userId !== cart.userId) {
       throw new HttpErrors.BadRequest(
@@ -50,8 +56,17 @@ export class ShoppingCartController {
    * Retrieve the shopping cart by user id
    * @param userId User id
    */
-  @get('/shoppingCarts/{userId}')
-  async get(@param.path.string('userId') userId: string) {
+  @get('/shoppingCarts/{userId}', {
+    responses: {
+      '200': {
+        description: 'User shopping cart is read',
+        content: {'application/json': {schema: {'x-ts-type': ShoppingCart}}},
+      },
+    },
+  })
+  async get(
+    @param.path.string('userId') userId: string,
+  ): Promise<ShoppingCart> {
     debug('Get shopping cart %s', userId);
     const cart = await this.shoppingCartRepository.get(userId);
     debug('Shopping cart %s: %j', userId, cart);
@@ -68,8 +83,14 @@ export class ShoppingCartController {
    * Delete the shopping cart by user id
    * @param userId User id
    */
-  @del('/shoppingCarts/{userId}')
-  async remove(@param.path.string('userId') userId: string) {
+  @del('/shoppingCarts/{userId}', {
+    responses: {
+      '204': {
+        description: 'User shopping cart is deleted',
+      },
+    },
+  })
+  async remove(@param.path.string('userId') userId: string): Promise<void> {
     debug('Remove shopping cart %s', userId);
     await this.shoppingCartRepository.delete(userId);
   }
@@ -79,11 +100,20 @@ export class ShoppingCartController {
    * @param userId User id
    * @param cart Shopping cart item to be added
    */
-  @post('/shoppingCarts/{userId}/items')
+  @post('/shoppingCarts/{userId}/items', {
+    responses: {
+      '200': {
+        description: 'User shopping cart item is created',
+        content: {
+          'application/json': {schema: {'x-ts-type': ShoppingCart}},
+        },
+      },
+    },
+  })
   async addItem(
     @param.path.string('userId') userId: string,
     @requestBody({description: 'shopping cart item'}) item: ShoppingCartItem,
-  ) {
+  ): Promise<ShoppingCart> {
     debug('Add item %j to shopping cart %s', item, userId);
     return this.shoppingCartRepository.addItem(userId, item);
   }

--- a/packages/shopping/src/controllers/user-order.controller.ts
+++ b/packages/shopping/src/controllers/user-order.controller.ts
@@ -3,7 +3,13 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {repository, Filter, Where, Count} from '@loopback/repository';
+import {
+  repository,
+  Filter,
+  Where,
+  Count,
+  CountSchema,
+} from '@loopback/repository';
 import {UserRepository} from '../repositories';
 import {
   post,
@@ -31,7 +37,7 @@ export class UserOrderController {
     responses: {
       '200': {
         description: 'User.Order model instance',
-        content: {'application/json': {'x-ts-type': Order}},
+        content: {'application/json': {schema: {'x-ts-type': Order}}},
       },
     },
   })
@@ -72,16 +78,7 @@ export class UserOrderController {
     responses: {
       '200': {
         description: 'User.Order PATCH success count',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                count: 'number',
-              },
-            },
-          },
-        },
+        content: {'application/json': {schema: CountSchema}},
       },
     },
   })
@@ -97,16 +94,7 @@ export class UserOrderController {
     responses: {
       '200': {
         description: 'User.Order DELETE success count',
-        content: {
-          'application/json': {
-            schema: {
-              type: 'object',
-              properties: {
-                count: 'number',
-              },
-            },
-          },
-        },
+        content: {'application/json': {schema: CountSchema}},
       },
     },
   })

--- a/packages/shopping/src/controllers/user.controller.ts
+++ b/packages/shopping/src/controllers/user.controller.ts
@@ -44,7 +44,20 @@ export class UserController {
     public userService: UserService<User, Credentials>,
   ) {}
 
-  @post('/users')
+  @post('/users', {
+    responses: {
+      '200': {
+        description: 'User',
+        content: {
+          'application/json': {
+            schema: {
+              'x-ts-type': User,
+            },
+          },
+        },
+      },
+    },
+  })
   async create(@requestBody() user: User): Promise<User> {
     // ensure a valid email value and password value
     validateCredentials(_.pick(user, ['email', 'password']));


### PR DESCRIPTION
1. Run `npm run docker:start && npm start; npm run docker:stop`
2. Run `npm install -g openapi-to-graphql`
3. Run `openapi-to-graphql --cors -p 3002 -f -u http://localhost:3000 http://localhost:3000/openapi.json`

## Before

```
OpenAPI-to-GraphQL creation event error:  Cannot use 'in' operator to search for '$ref' in number
(node:65318) UnhandledPromiseRejectionWarning: AssertionError: Schema object cannot have additionalProperty: patternProperties
    at Assertion.fail (.../node_modules/should/as-function.js:275:17)
    at Assertion.value (.../node_modules/should/as-function.js:356:19)
    at checkSubSchema (.../node_modules/oas-validator/index.js:132:16)
    at walkSchema (.../node_modules/oas-schema-walker/index.js:53:5)
    at Object.walkSchema (.../node_modules/oas-schema-walker/index.js:82:13)
    at checkSchema (.../node_modules/oas-validator/index.js:343:8)
    at checkContent (.../node_modules/oas-validator/index.js:391:13)
    at checkResponse (.../node_modules/oas-validator/index.js:581:9)
    at checkPathItem (.../node_modules/oas-validator/index.js:796:21)
    at .../node_modules/oas-validator/index.js:1188:13
(node:65318) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:65318) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

* After changing `properties: { count: 'number' }` to `properties: { count: { type: 'number' } }` in `UserOrderController`, try again:

```
{
  "warnings": [
    {
      "type": "MISSING_RESPONSE_SCHEMA",
      "message": "Operation POST /shoppingCarts/{userId}/items has no (valid) response schema. If this operation has a 204 HTTP code, you can create a placeholder schema using 
the fillEmptyResponses option.",
      "mitigation": "Ignore operation."
    },
    {
      "type": "MISSING_RESPONSE_SCHEMA",
      "message": "Operation PUT /shoppingCarts/{userId} has no (valid) response schema. If this operation has a 204 HTTP code, you can create a placeholder schema using the fil
lEmptyResponses option.",
      "mitigation": "Ignore operation."
    },
    {
      "type": "MISSING_RESPONSE_SCHEMA",
      "message": "Operation GET /shoppingCarts/{userId} has no (valid) response schema. If this operation has a 204 HTTP code, you can create a placeholder schema using the fil
lEmptyResponses option.",
      "mitigation": "Ignore operation."
    },
    {
      "type": "MISSING_RESPONSE_SCHEMA",
      "message": "Operation DELETE /shoppingCarts/{userId} has no (valid) response schema. If this operation has a 204 HTTP code, you can create a placeholder schema using the fillEmptyResponses option.",
      "mitigation": "Ignore operation."
    },
    {
      "type": "MISSING_RESPONSE_SCHEMA",
      "message": "Operation POST /users/{userId}/orders has no (valid) response schema. If this operation has a 204 HTTP code, you can create a placeholder schema using the fillEmptyResponses option.",
      "mitigation": "Ignore operation."
    },
    {
      "type": "MISSING_RESPONSE_SCHEMA",
      "message": "Operation POST /users has no (valid) response schema. If this operation has a 204 HTTP code, you can create a placeholder schema using the fillEmptyResponses option.",
      "mitigation": "Ignore operation."
    },
    {
      "type": "OBJECT_MISSING_PROPERTIES",
      "message": "The operation 'GET /ping' contains a object schema {\"preferredName\":\"headers\",\"schema\":{\"type\":\"object\",\"patternProperties\":{\"^.*$\":{\"type\":\"string\"}},\"additionalProperties\":false},\"type\":\"object\",\"subDefinitions\":{},\"links\":{},\"otName\":\"Headers\",\"iotName\":\"HeadersInput\"} with no properties. GraphQL objects must have well-defined properties so a one to one conversion cannot be achieved.",
      "mitigation": "The (sub-)object will be stringified. The property will return a string in the interface."
    }
  ],
  "numOps": 14,
  "numOpsQuery": 6,
  "numOpsMutation": 8,
  "numQueriesCreated": 5,
  "numMutationsCreated": 3
}
GraphQL accessible at: http://localhost:3002/graphql
(node:65423) UnhandledPromiseRejectionWarning: AssertionError: Schema object cannot have additionalProperty: patternProperties
    at Assertion.fail (.../node_modules/should/as-function.js:275:17)
    at Assertion.value (.../node_modules/should/as-function.js:356:19)
    at checkSubSchema (.../node_modules/oas-validator/index.js:132:16)
    at walkSchema (.../node_modules/oas-schema-walker/index.js:53:5)
    at Object.walkSchema (.../node_modules/oas-schema-walker/index.js:82:13)
    at checkSchema (.../node_modules/oas-validator/index.js:343:8)
    at checkContent (.../node_modules/oas-validator/index.js:391:13)
    at checkResponse (.../node_modules/oas-validator/index.js:581:9)
    at checkPathItem (.../node_modules/oas-validator/index.js:796:21)
    at .../node_modules/oas-validator/index.js:1188:13
(node:65423) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:65423) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

* Removed usage of `patternProperties` ping controller.
* Fixed response schemas of the endpoints listed in the warnings.

## After

```
{
  "warnings": [],
  "numOps": 14,
  "numOpsQuery": 6,
  "numOpsMutation": 8,
  "numQueriesCreated": 6,
  "numMutationsCreated": 8
}
GraphQL accessible at: http://localhost:3002/graphql
```

![GraphiQL Dashboard](https://user-images.githubusercontent.com/12089120/61180757-255ad080-a5d0-11e9-95e0-7513d7e940a4.png)

Signed-off-by: Omar Chehab <omarchehab98@gmail.com>