### PR TITLE
refactor: correct misleading variable name

### DIFF
--- a/packages/shopping/src/services/jwt-service.ts
+++ b/packages/shopping/src/services/jwt-service.ts
@@ -32,11 +32,11 @@ export class JWTService implements TokenService {
 
     try {
       // decode user profile from token
-      const decryptedToken = await verifyAsync(token, this.jwtSecret);
+      const decodedToken = await verifyAsync(token, this.jwtSecret);
       // don't copy over  token field 'iat' and 'exp', nor 'email' to user profile
       userProfile = Object.assign(
         {id: '', name: ''},
-        {id: decryptedToken.id, name: decryptedToken.name},
+        {id: decodedToken.id, name: decodedToken.name},
       );
     } catch (error) {
       throw new HttpErrors.Unauthorized(


### PR DESCRIPTION
Correct naming from `decryptedToken` to `decodedToken`. The prior naming is misleading as it implies
that the token is encrypted instead of encoded.