### PR TITLE
refactor: change login error message

### DIFF
--- a/packages/shopping/src/__tests__/acceptance/user.controller.acceptance.ts
+++ b/packages/shopping/src/__tests__/acceptance/user.controller.acceptance.ts
@@ -155,11 +155,9 @@ describe('UserController', () => {
       const res = await client
         .post('/users/login')
         .send({email: 'idontexist@example.com', password: user.password})
-        .expect(404);
+        .expect(401);
 
-      expect(res.body.error.message).to.equal(
-        'User with email idontexist@example.com not found.',
-      );
+      expect(res.body.error.message).to.equal('Invalid email or password.');
     });
 
     it('login returns an error when invalid password is used', async () => {
@@ -170,9 +168,7 @@ describe('UserController', () => {
         .send({email: newUser.email, password: 'wrongpassword'})
         .expect(401);
 
-      expect(res.body.error.message).to.equal(
-        'The credentials are not correct.',
-      );
+      expect(res.body.error.message).to.equal('Invalid email or password.');
     });
 
     it('users/me returns the current user profile when a valid JWT token is provided', async () => {

--- a/packages/shopping/src/__tests__/unit/utils.authentication.unit.ts
+++ b/packages/shopping/src/__tests__/unit/utils.authentication.unit.ts
@@ -87,8 +87,8 @@ describe('authentication services', () => {
   it('user service verifyCredentials() fails with user not found', async () => {
     const credentials = {email: 'idontexist@example.com', password: 'p4ssw0rd'};
 
-    const expectedError = new HttpErrors.NotFound(
-      `User with email ${credentials.email} not found.`,
+    const expectedError = new HttpErrors.Unauthorized(
+      'Invalid email or password.',
     );
 
     await expect(userService.verifyCredentials(credentials)).to.be.rejectedWith(
@@ -100,7 +100,7 @@ describe('authentication services', () => {
     const {email} = newUser;
     const credentials = {email, password: 'invalidp4ssw0rd'};
     const expectedError = new HttpErrors.Unauthorized(
-      'The credentials are not correct.',
+      'Invalid email or password.',
     );
 
     await expect(userService.verifyCredentials(credentials)).to.be.rejectedWith(

--- a/packages/shopping/src/services/user-service.ts
+++ b/packages/shopping/src/services/user-service.ts
@@ -19,14 +19,14 @@ export class MyUserService implements UserService<User, Credentials> {
   ) {}
 
   async verifyCredentials(credentials: Credentials): Promise<User> {
+    const invalidCredentialsError = 'Invalid email or password.';
+
     const foundUser = await this.userRepository.findOne({
       where: {email: credentials.email},
     });
 
     if (!foundUser) {
-      throw new HttpErrors.NotFound(
-        `User with email ${credentials.email} not found.`,
-      );
+      throw new HttpErrors.Unauthorized(invalidCredentialsError);
     }
     const passwordMatched = await this.passwordHasher.comparePassword(
       credentials.password,
@@ -34,7 +34,7 @@ export class MyUserService implements UserService<User, Credentials> {
     );
 
     if (!passwordMatched) {
-      throw new HttpErrors.Unauthorized('The credentials are not correct.');
+      throw new HttpErrors.Unauthorized(invalidCredentialsError);
     }
 
     return foundUser;


### PR DESCRIPTION
The error message returned on a failed login attempt should always be the same regardless of whether
the email or the password is wrong. Since this is a showcase application, it should adhere to security best practices. As a reference see [OWASP recommendation](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#login).