### PR TITLE
feat: enable auth token dialog in api explorer

### DIFF
--- a/packages/shopping/src/application.ts
+++ b/packages/shopping/src/application.ts
@@ -29,6 +29,7 @@ import {
 import {PasswordHasherBindings} from './keys';
 import {BcryptHasher} from './services/hash.password.bcryptjs';
 import {JWTAuthenticationStrategy} from './authentication-strategies/jwt-strategy';
+import {SECURITY_SCHEME_SPEC} from './utils/security-spec';
 
 /**
  * Information from package.json
@@ -47,6 +48,19 @@ export class ShoppingApplication extends BootMixin(
 ) {
   constructor(options?: ApplicationConfig) {
     super(options);
+
+    /*
+       This is a workaround until an extension point is introduced
+       allowing extensions to contribute to the OpenAPI specification
+       dynamically.
+    */
+    this.api({
+      openapi: '3.0.0',
+      info: {title: pkg.name, version: pkg.version},
+      paths: {},
+      components: {securitySchemes: SECURITY_SCHEME_SPEC},
+      servers: [{url: '/'}],
+    });
 
     this.setUpBindings();
 

--- a/packages/shopping/src/controllers/user.controller.ts
+++ b/packages/shopping/src/controllers/user.controller.ts
@@ -29,6 +29,7 @@ import {
   UserServiceBindings,
 } from '../keys';
 import * as _ from 'lodash';
+import {OPERATION_SECURITY_SPEC} from '../utils/security-spec';
 
 export class UserController {
   constructor(
@@ -102,6 +103,7 @@ export class UserController {
   }
 
   @get('/users/me', {
+    security: OPERATION_SECURITY_SPEC,
     responses: {
       '200': {
         description: 'The current user profile',

--- a/packages/shopping/src/utils/security-spec.ts
+++ b/packages/shopping/src/utils/security-spec.ts
@@ -1,0 +1,18 @@
+// Copyright IBM Corp. 2018,2019. All Rights Reserved.
+// Node module: loopback4-example-shopping
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {SecuritySchemeObject, ReferenceObject} from '@loopback/openapi-v3';
+
+export const OPERATION_SECURITY_SPEC = [{bearerAuth: []}];
+export type SecuritySchemeObjects = {
+  [securityScheme: string]: SecuritySchemeObject | ReferenceObject;
+};
+export const SECURITY_SCHEME_SPEC: SecuritySchemeObjects = {
+  bearerAuth: {
+    type: 'http',
+    scheme: 'bearer',
+    bearerFormat: 'JWT',
+  },
+};


### PR DESCRIPTION
Make the authentication token dialog available in API Explorer

Connected to https://github.com/strongloop/loopback-next/issues/3740
