### PR TITLE
feat: extract local credentials into a new model

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,16 @@ http://[::1]:3000/explorer/.
 
 ## Models
 
-This app has five models:
+This app has the following models:
 
 1. `User` - representing the users of the system.
-2. `Product` - a model which is mapped to a remote service by
+2. `UserCredentials` - representing sensitive credentials like a password.
+3. `Product` - a model which is mapped to a remote service by
    `services/recommender.service`.
-3. `ShoppingCartItem` - a model for representing purchases.
-4. `ShoppingCart` - a model to represent a user's shopping cart, can contain
+4. `ShoppingCartItem` - a model for representing purchases.
+5. `ShoppingCart` - a model to represent a user's shopping cart, can contain
    many items (`items`) of the type `ShoppingCartItem`.
-5. `Order` - a model to represent an order by user, can have many products
+6. `Order` - a model to represent an order by user, can have many products
    (`products`) of the type `ShoppingCartItem`.
 
 `ShoppingCart` and `Order` are marked as belonging to the `User` model by the
@@ -49,6 +50,10 @@ use of the `@belongsTo` model decorator. Correspondingly, the `User` model is
 marked as having many `Order`s using the `@hasMany` model decorator. Although
 possible, a `hasMany` relation for `User` to `ShoppingCart` has not be created
 in this particular app to limit the scope of the example.
+
+`User` is also marked as having one `UserCredentials` model using the `@hasOne`
+decorator. The `belongsTo` relation for `UserCredentials` to `User` has not been
+created to keep the scope smaller.
 
 ## Controllers
 

--- a/packages/shopping/src/__tests__/acceptance/authorization.acceptance.ts
+++ b/packages/shopping/src/__tests__/acceptance/authorization.acceptance.ts
@@ -16,11 +16,12 @@ describe('authorization', () => {
   let client: Client;
   let userRepo: UserRepository;
 
-  let user = {
+  let userData = {
     email: 'testAuthor@loopback.io',
-    password: 'p4ssw0rd',
     firstName: 'customer_service',
   };
+
+  const userPassword = 'p4ssw0rd';
 
   let passwordHasher: PasswordHasher;
   let newUser: User;
@@ -54,7 +55,7 @@ describe('authorization', () => {
 
       let res = await client
         .post('/users/login')
-        .send({email: newUser.email, password: user.password})
+        .send({email: newUser.email, password: userPassword})
         .expect(200);
 
       token = res.body.token;
@@ -82,9 +83,8 @@ describe('authorization', () => {
 
   describe('bob', () => {
     it('allows bob create orders', async () => {
-      user = {
+      userData = {
         email: 'test2@loopback.io',
-        password: 'p4ssw0rd',
         firstName: 'bob',
       };
       newUser = await createAUser();
@@ -102,7 +102,7 @@ describe('authorization', () => {
 
       let res = await client
         .post('/users/login')
-        .send({email: newUser.email, password: user.password})
+        .send({email: newUser.email, password: userPassword})
         .expect(200);
 
       token = res.body.token;
@@ -145,13 +145,15 @@ describe('authorization', () => {
   }
 
   async function createAUser() {
-    const encryptedPassword = await passwordHasher.hashPassword(user.password);
-    const aUser = await userRepo.create(
-      Object.assign({}, user, {password: encryptedPassword}),
-    );
+    const encryptedPassword = await passwordHasher.hashPassword(userPassword);
+    const aUser = await userRepo.create(userData);
+
     // MongoDB returns an id object we need to convert to string
     aUser.id = aUser.id.toString();
 
+    await userRepo.userCredentials(aUser.id).create({
+      password: encryptedPassword,
+    });
     return aUser;
   }
 

--- a/packages/shopping/src/models/index.ts
+++ b/packages/shopping/src/models/index.ts
@@ -8,3 +8,4 @@ export * from './shopping-cart-item.model';
 export * from './shopping-cart.model';
 export * from './order.model';
 export * from './product.model';
+export * from './user-credentials.model';

--- a/packages/shopping/src/models/user-credentials.model.ts
+++ b/packages/shopping/src/models/user-credentials.model.ts
@@ -1,0 +1,40 @@
+// Copyright IBM Corp. 2018. All Rights Reserved.
+// Node module: loopback4-example-shopping
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class UserCredentials extends Entity {
+  @property({
+    type: 'string',
+    id: true,
+    mongodb: {dataType: 'ObjectID'},
+  })
+  id: string;
+
+  @property({
+    type: 'string',
+    required: true,
+  })
+  password: string;
+
+  @property({
+    type: 'string',
+    required: true,
+    mongodb: {dataType: 'ObjectID'},
+  })
+  userId: string;
+
+  constructor(data?: Partial<UserCredentials>) {
+    super(data);
+  }
+}
+
+export interface UserCredentialsRelations {
+  // describe navigational properties here
+}
+
+export type UserCredentialsWithRelations = UserCredentials &
+  UserCredentialsRelations;

--- a/packages/shopping/src/models/user.model.ts
+++ b/packages/shopping/src/models/user.model.ts
@@ -1,10 +1,11 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Entity, model, property, hasMany} from '@loopback/repository';
+import {Entity, model, property, hasMany, hasOne} from '@loopback/repository';
 import {Order} from './order.model';
+import {UserCredentials} from './user-credentials.model';
 
 @model({
   settings: {
@@ -35,12 +36,6 @@ export class User extends Entity {
 
   @property({
     type: 'string',
-    required: true,
-  })
-  password: string;
-
-  @property({
-    type: 'string',
   })
   firstName?: string;
 
@@ -51,6 +46,9 @@ export class User extends Entity {
 
   @hasMany(() => Order)
   orders: Order[];
+
+  @hasOne(() => UserCredentials)
+  userCredentials: UserCredentials;
 
   constructor(data?: Partial<User>) {
     super(data);

--- a/packages/shopping/src/repositories/index.ts
+++ b/packages/shopping/src/repositories/index.ts
@@ -6,3 +6,4 @@
 export * from './user.repository';
 export * from './shopping-cart.repository';
 export * from './order.repository';
+export * from './user-credentials.repository';

--- a/packages/shopping/src/repositories/user-credentials.repository.ts
+++ b/packages/shopping/src/repositories/user-credentials.repository.ts
@@ -1,0 +1,18 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: loopback4-example-shopping
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {DefaultCrudRepository, juggler} from '@loopback/repository';
+import {UserCredentials, UserCredentialsRelations} from '../models';
+import {inject} from '@loopback/core';
+
+export class UserCredentialsRepository extends DefaultCrudRepository<
+  UserCredentials,
+  typeof UserCredentials.prototype.id,
+  UserCredentialsRelations
+> {
+  constructor(@inject('datasources.mongo') dataSource: juggler.DataSource) {
+    super(UserCredentials, dataSource);
+  }
+}

--- a/packages/shopping/src/services/user-service.ts
+++ b/packages/shopping/src/services/user-service.ts
@@ -25,13 +25,20 @@ export class MyUserService implements UserService<User, Credentials> {
     const foundUser = await this.userRepository.findOne({
       where: {email: credentials.email},
     });
-
     if (!foundUser) {
       throw new HttpErrors.Unauthorized(invalidCredentialsError);
     }
+
+    const credentialsFound = await this.userRepository.findCredentials(
+      foundUser.id,
+    );
+    if (!credentialsFound) {
+      throw new HttpErrors.Unauthorized(invalidCredentialsError);
+    }
+
     const passwordMatched = await this.passwordHasher.comparePassword(
       credentials.password,
-      foundUser.password,
+      credentialsFound.password,
     );
 
     if (!passwordMatched) {

--- a/packages/shopping/src/services/validator.ts
+++ b/packages/shopping/src/services/validator.ts
@@ -14,7 +14,7 @@ export function validateCredentials(credentials: Credentials) {
   }
 
   // Validate Password Length
-  if (credentials.password.length < 8) {
+  if (!credentials.password || credentials.password.length < 8) {
     throw new HttpErrors.UnprocessableEntity(
       'password must be minimum 8 characters',
     );


### PR DESCRIPTION
Introduce `UserCredentials` models to hold hashed passwords, add has-one relation from `User` to `UserCredentials`.

Rework authentication-related code to work with the new domain model.

See https://github.com/strongloop/loopback-next/issues/1996 for additional information.

_I have to say the code in the example app is a bit messy. Some things are (unnecessarily) duplicated in multiple places, therefore my pull request had to touch quite few files to update all duplications. Considering our current priorities, I am leaving refactoring & cleanup out of scope of my PR._