### PR TITLE
feat: enable migrateSchema so that users/products are populated with npm start

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,16 +15,15 @@
   },
   "files.insertFinalNewline": true,
   "files.trimTrailingWhitespace": true,
-  "eslint.autoFixOnSave": true,
   "eslint.run": "onSave",
   "eslint.nodePath": "./node_modules",
   "eslint.validate": [
     "javascript",
-    {
-      "language": "typescript",
-      "autoFix": true
-    }
+    "typescript"
   ],
   "typescript.tsdk": "./node_modules/typescript/lib",
-  "git.alwaysSignOff": true
+  "git.alwaysSignOff": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  }
 }

--- a/packages/shopping/src/__tests__/acceptance/authentication.acceptance.ts
+++ b/packages/shopping/src/__tests__/acceptance/authentication.acceptance.ts
@@ -38,7 +38,7 @@ describe('authentication services', () => {
 
   before(setupApp);
   after(async () => {
-    await app.stop();
+    if (app != null) await app.stop();
   });
 
   let userRepo: UserRepository;
@@ -201,7 +201,7 @@ describe('authentication services', () => {
   async function setupApp() {
     const appWithClient = await setupApplication();
     app = appWithClient.app;
-    app.bind(PasswordHasherBindings.ROUNDS).to(4);
+    app.bind(PasswordHasherBindings.ROUNDS).to(2);
   }
 
   async function createUser() {

--- a/packages/shopping/src/__tests__/acceptance/authorization.acceptance.ts
+++ b/packages/shopping/src/__tests__/acceptance/authorization.acceptance.ts
@@ -35,7 +35,7 @@ describe('authorization', () => {
   before(createPasswordHasher);
   before(clearDatabase);
   after(async () => {
-    await app.stop();
+    if (app != null) await app.stop();
   });
 
   describe('customer_service', () => {

--- a/packages/shopping/src/__tests__/acceptance/helper.ts
+++ b/packages/shopping/src/__tests__/acceptance/helper.ts
@@ -18,6 +18,7 @@ export interface AppWithClient {
 export async function setupApplication(): Promise<AppWithClient> {
   const app = new ShoppingApplication({
     rest: givenHttpServerConfig(),
+    databaseSeeding: false,
   });
 
   await app.boot();

--- a/packages/shopping/src/application.ts
+++ b/packages/shopping/src/application.ts
@@ -146,6 +146,15 @@ export class ShoppingApplication extends BootMixin(
     this.bind(UserServiceBindings.USER_SERVICE).toClass(MyUserService);
   }
 
+  async start() {
+    // Use `databaseSeeding` flag to control if products/users should be pre
+    // populated into the database. Its value is default to `true`.
+    if (this.options.databaseSeeding !== false) {
+      await this.migrateSchema();
+    }
+    return super.start();
+  }
+
   async migrateSchema(options?: SchemaMigrationOptions) {
     await super.migrateSchema(options);
 


### PR DESCRIPTION
Before this PR, the `Shoppy` login fails as there are no pre-defined users/products populated.

@hacksparrow Do you have docs to describe that?