### PR TITLE
chore: update copyrights year

### DIFF
--- a/packages/recommender/index.d.ts
+++ b/packages/recommender/index.d.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: loopback4-example-recommender
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/recommender/src/__tests__/integration/recommender-grpc.integration.ts
+++ b/packages/recommender/src/__tests__/integration/recommender-grpc.integration.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: loopback4-example-recommender
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/recommender/src/__tests__/integration/recommender-rest.integration.ts
+++ b/packages/recommender/src/__tests__/integration/recommender-rest.integration.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: loopback4-example-recommender
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/recommender/src/index.ts
+++ b/packages/recommender/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: loopback4-example-recommender
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/recommender/src/recommendation-grpc.ts
+++ b/packages/recommender/src/recommendation-grpc.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: loopback4-example-recommender
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/recommender/src/recommendation-rest.ts
+++ b/packages/recommender/src/recommendation-rest.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: loopback4-example-recommender
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/index.js
+++ b/packages/shopping/index.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/index.ts
+++ b/packages/shopping/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/public/api.js
+++ b/packages/shopping/public/api.js
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
+// Node module: loopback4-example-shopping
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 /*global apiUrl, localStorage, $*/
 
 'use strict';

--- a/packages/shopping/public/config.js
+++ b/packages/shopping/public/config.js
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: loopback4-example-shopping
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 'use strict';
 
 const apiUrl = 'http://localhost:3000';

--- a/packages/shopping/public/product.js
+++ b/packages/shopping/public/product.js
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
+// Node module: loopback4-example-shopping
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 /*global templates, util, alert, api, DOMPurify, $*/
 'use strict';
 

--- a/packages/shopping/public/profile.js
+++ b/packages/shopping/public/profile.js
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: loopback4-example-shopping
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 /*global templates, util, alert, api, DOMPurify, $*/
 'use strict';
 

--- a/packages/shopping/public/purify.js
+++ b/packages/shopping/public/purify.js
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: loopback4-example-shopping
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 /*
 Library: https://github.com/cure53/DOMPurify
 File: Latest version available at https://github.com/cure53/DOMPurify/blob/master/dist/purify.min.js

--- a/packages/shopping/public/shoppy.js
+++ b/packages/shopping/public/shoppy.js
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
+// Node module: loopback4-example-shopping
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 /*global templates, ui, util, api, config, DOMPurify, $*/
 'use strict';
 

--- a/packages/shopping/public/templates.js
+++ b/packages/shopping/public/templates.js
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: loopback4-example-shopping
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 'use strict';
 
 const navBarTemplate = `

--- a/packages/shopping/public/ui.js
+++ b/packages/shopping/public/ui.js
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: loopback4-example-shopping
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 /*global apiUrl, localStorage, api, ui, location, config, document, templates, util, alert, DOMPurify, profilePage, ordersPage, homePage, $*/
 'use strict';
 

--- a/packages/shopping/public/util.js
+++ b/packages/shopping/public/util.js
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: loopback4-example-shopping
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 /*global location, localStorage, DOMPurify, api*/
 'use strict';
 

--- a/packages/shopping/src/__tests__/acceptance/authentication.acceptance.ts
+++ b/packages/shopping/src/__tests__/acceptance/authentication.acceptance.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2019. All Rights Reserved.
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/__tests__/acceptance/authorization.acceptance.ts
+++ b/packages/shopping/src/__tests__/acceptance/authorization.acceptance.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018,2019. All Rights Reserved.
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/__tests__/acceptance/helper.ts
+++ b/packages/shopping/src/__tests__/acceptance/helper.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/__tests__/acceptance/home-page.acceptance.ts
+++ b/packages/shopping/src/__tests__/acceptance/home-page.acceptance.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/__tests__/acceptance/ping.controller.acceptance.ts
+++ b/packages/shopping/src/__tests__/acceptance/ping.controller.acceptance.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/__tests__/acceptance/shopping-cart.controller.acceptance.ts
+++ b/packages/shopping/src/__tests__/acceptance/shopping-cart.controller.acceptance.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/__tests__/acceptance/user-order.controller.acceptance.ts
+++ b/packages/shopping/src/__tests__/acceptance/user-order.controller.acceptance.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/__tests__/acceptance/user.controller.acceptance.ts
+++ b/packages/shopping/src/__tests__/acceptance/user.controller.acceptance.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018,2019. All Rights Reserved.
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/__tests__/fixtures/redis-mongo-docker.ts
+++ b/packages/shopping/src/__tests__/fixtures/redis-mongo-docker.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/__tests__/integration/shopping-cart.repository.integration.ts
+++ b/packages/shopping/src/__tests__/integration/shopping-cart.repository.integration.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/__tests__/unit/utils.retry.unit.ts
+++ b/packages/shopping/src/__tests__/unit/utils.retry.unit.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/application.ts
+++ b/packages/shopping/src/application.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018,2019. All Rights Reserved.
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/authentication-strategies/jwt-strategy.ts
+++ b/packages/shopping/src/authentication-strategies/jwt-strategy.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2019. All Rights Reserved.
-// Node module: @loopback/authentication
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/packages/shopping/src/controllers/index.ts
+++ b/packages/shopping/src/controllers/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/controllers/ping.controller.ts
+++ b/packages/shopping/src/controllers/ping.controller.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/controllers/product.controller.ts
+++ b/packages/shopping/src/controllers/product.controller.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
+// Node module: loopback4-example-shopping
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {
   Count,
   CountSchema,

--- a/packages/shopping/src/controllers/shopping-cart.controller.ts
+++ b/packages/shopping/src/controllers/shopping-cart.controller.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/controllers/specs/user-controller.specs.ts
+++ b/packages/shopping/src/controllers/specs/user-controller.specs.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2019. All Rights Reserved.
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/controllers/user-order.controller.ts
+++ b/packages/shopping/src/controllers/user-order.controller.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/controllers/user.controller.ts
+++ b/packages/shopping/src/controllers/user.controller.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018,2019. All Rights Reserved.
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/datasources/index.ts
+++ b/packages/shopping/src/datasources/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/datasources/mongo.datasource.ts
+++ b/packages/shopping/src/datasources/mongo.datasource.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/datasources/recommender-grpc.datasource.ts
+++ b/packages/shopping/src/datasources/recommender-grpc.datasource.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: loopback4-example-shopping
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {inject} from '@loopback/core';
 import {juggler, AnyObject} from '@loopback/repository';
 import path from 'path';

--- a/packages/shopping/src/datasources/recommender.datasource.ts
+++ b/packages/shopping/src/datasources/recommender.datasource.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/datasources/redis.datasource.ts
+++ b/packages/shopping/src/datasources/redis.datasource.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/index.ts
+++ b/packages/shopping/src/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/keys.ts
+++ b/packages/shopping/src/keys.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2019. All Rights Reserved.
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/migrate.ts
+++ b/packages/shopping/src/migrate.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: loopback4-example-shopping
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {ShoppingApplication} from './application';
 
 export async function migrate(args: string[]) {

--- a/packages/shopping/src/models/index.ts
+++ b/packages/shopping/src/models/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/models/order.model.ts
+++ b/packages/shopping/src/models/order.model.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/models/product.model.ts
+++ b/packages/shopping/src/models/product.model.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/models/shopping-cart-item.model.ts
+++ b/packages/shopping/src/models/shopping-cart-item.model.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/models/shopping-cart.model.ts
+++ b/packages/shopping/src/models/shopping-cart.model.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/models/user-credentials.model.ts
+++ b/packages/shopping/src/models/user-credentials.model.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/models/user.model.ts
+++ b/packages/shopping/src/models/user.model.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2019. All Rights Reserved.
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/repositories/index.ts
+++ b/packages/shopping/src/repositories/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/repositories/order.repository.ts
+++ b/packages/shopping/src/repositories/order.repository.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/repositories/product.repository.ts
+++ b/packages/shopping/src/repositories/product.repository.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
+// Node module: loopback4-example-shopping
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {DefaultCrudRepository} from '@loopback/repository';
 import {Product, ProductRelations} from '../models';
 import {MongoDataSource} from '../datasources';

--- a/packages/shopping/src/repositories/shopping-cart.repository.ts
+++ b/packages/shopping/src/repositories/shopping-cart.repository.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/repositories/user.repository.ts
+++ b/packages/shopping/src/repositories/user.repository.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/sequence.ts
+++ b/packages/shopping/src/sequence.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018,2019. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/services/basic.authorizor.ts
+++ b/packages/shopping/src/services/basic.authorizor.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: loopback4-example-shopping
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {
   AuthorizationContext,
   AuthorizationMetadata,

--- a/packages/shopping/src/services/id.compare.authorizor.ts
+++ b/packages/shopping/src/services/id.compare.authorizor.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
+// Node module: loopback4-example-shopping
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {
   AuthorizationContext,
   AuthorizationMetadata,

--- a/packages/shopping/src/services/index.ts
+++ b/packages/shopping/src/services/index.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/services/jwt-service.ts
+++ b/packages/shopping/src/services/jwt-service.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2019. All Rights Reserved.
-// Node module: @loopback/authentication
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/packages/shopping/src/services/recommender-grpc.service.ts
+++ b/packages/shopping/src/services/recommender-grpc.service.ts
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: loopback4-example-shopping
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
 import {getService} from '@loopback/service-proxy';
 import {inject, Provider, bind} from '@loopback/core';
 import {RecommenderGrpcDataSource} from '../datasources';

--- a/packages/shopping/src/services/recommender-rest.service.ts
+++ b/packages/shopping/src/services/recommender-rest.service.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/services/recommender.service.ts
+++ b/packages/shopping/src/services/recommender.service.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/services/user-service.ts
+++ b/packages/shopping/src/services/user-service.ts
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2019. All Rights Reserved.
-// Node module: @loopback/authentication
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
+
 import {HttpErrors} from '@loopback/rest';
 import {Credentials, UserRepository} from '../repositories/user.repository';
 import {User} from '../models/user.model';

--- a/packages/shopping/src/services/validator.ts
+++ b/packages/shopping/src/services/validator.ts
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2019. All Rights Reserved.
-// Node module: @loopback/authentication
+// Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 

--- a/packages/shopping/src/utils/retry.ts
+++ b/packages/shopping/src/utils/retry.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018. All Rights Reserved.
+// Copyright IBM Corp. 2019. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT

--- a/packages/shopping/src/utils/security-spec.ts
+++ b/packages/shopping/src/utils/security-spec.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2018,2019. All Rights Reserved.
+// Copyright IBM Corp. 2019,2020. All Rights Reserved.
 // Node module: loopback4-example-shopping
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT


### PR DESCRIPTION
Related: strongloop-internal/scrum-apex#440

Update the copyrights year in the rest of the packages besides #4596.

The changes are introduced by running the `slt copyright` command. I'm skipping the fixtures folders.