### PR TITLE
refactor: change duplicate email error

### DIFF
--- a/packages/shopping/src/__tests__/acceptance/user.controller.acceptance.ts
+++ b/packages/shopping/src/__tests__/acceptance/user.controller.acceptance.ts
@@ -148,7 +148,7 @@ describe('UserController', () => {
     const res = await client
       .post('/users')
       .send({...userData, password: userPassword})
-      .expect(409);
+      .expect(422);
 
     expect(res.body.error.message).to.equal('Email value is already taken');
   });

--- a/packages/shopping/src/__tests__/acceptance/user.controller.acceptance.ts
+++ b/packages/shopping/src/__tests__/acceptance/user.controller.acceptance.ts
@@ -18,7 +18,7 @@ import {JWTService} from '../../services/jwt-service';
 import {securityId} from '@loopback/security';
 import {RecommenderService} from '../../services';
 import {Server} from 'grpc';
-import {HTTPError} from 'superagent';
+import {ResponseError} from 'superagent';
 
 const recommendations = require('loopback4-example-recommender/data/recommendations.json');
 
@@ -93,7 +93,7 @@ describe('UserController', () => {
       .expect(422);
 
     expect(res.error).to.not.eql(false);
-    const resError = res.error as HTTPError;
+    const resError = res.error as ResponseError;
     const errorText = JSON.parse(resError.text);
     expect(errorText.error.details[0].info.missingProperty).to.equal('email');
   });
@@ -123,7 +123,7 @@ describe('UserController', () => {
       .expect(422);
 
     expect(res.error).to.not.eql(false);
-    const resError = res.error as HTTPError;
+    const resError = res.error as ResponseError;
     const errorText = JSON.parse(resError.text);
     expect(errorText.error.details[0].info.missingProperty).to.equal(
       'password',

--- a/packages/shopping/src/controllers/user.controller.ts
+++ b/packages/shopping/src/controllers/user.controller.ts
@@ -114,7 +114,9 @@ export class UserController {
     } catch (error) {
       // MongoError 11000 duplicate key
       if (error.code === 11000 && error.errmsg.includes('index: uniqueEmail')) {
-        throw new HttpErrors.Conflict('Email value is already taken');
+        throw new HttpErrors.UnprocessableEntity(
+          'Email value is already taken',
+        );
       } else {
         throw error;
       }


### PR DESCRIPTION
Change user controller email conflict error to 'UnprocessableEntity' as more appropriate.

Signed-off-by: Douglas McConnachie <dougal83+git@gmail.com>