### PR TITLE
fix: remove ref for v4.loopback.io

### DIFF
--- a/packages/shopping/public/index.html
+++ b/packages/shopping/public/index.html
@@ -7,7 +7,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="shortcut icon" type="image/x-icon" href="//v4.loopback.io/favicon.ico">
+  <link rel="shortcut icon" type="image/x-icon" href="https://loopback.io/favicon.ico">
 
   <style>
     h3 {
@@ -65,7 +65,7 @@
   </div>
 
   <footer class="power">
-    <a href="https://v4.loopback.io" target="_blank">
+    <a href="https://loopback.io" target="_blank">
       <img src="https://loopback.io/images/branding/powered-by-loopback/blue/powered-by-loopback-sm.png" />
     </a>
   </footer>


### PR DESCRIPTION
Since v4.loopback.io is no longer in use, remove any references for v4.loopback.io. 
