### PR TITLE
chore: enable StaleBot using config from loopback-next

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,56 @@
+# Configuration for Stale Bot
+# Learn more at https://github.com/probot/stale
+
+# Issues and pull requests with these labels will never be considered stale
+exemptLabels:
+  - planning
+  - committed
+  - in-progress
+  - pinned
+  - security
+  - critical
+  - p1
+  - major
+  - good first issue
+
+# Label to use when marking an issue or a PR as stale
+staleLabel: stale
+
+# Configuration for issues
+issues:
+
+  # Number of days of inactivity before an issue becomes stale
+  daysUntilStale: 180
+  # Comment to post when marking an issue as stale. Set to `false` to disable
+  markComment: >
+    This issue has been marked stale because it has not seen activity within
+    six months. If you believe this to be in error, please contact one of the code owners,
+    listed in the `CODEOWNERS` file at the top-level of this repository.
+    This issue will be closed within 30 days of being stale.
+
+  # Number of days of inactivity before a stale issue is closed
+  daysUntilClose: 30
+  # Comment to post when closing a stale issue. Set to `false` to disable
+  closeComment: >
+    This issue has been closed due to continued inactivity. Thank you for your understanding.
+    If you believe this to be in error, please contact one of the code owners,
+    listed in the `CODEOWNERS` file at the top-level of this repository.
+
+# Configuration for pull requests
+pulls:
+
+  # Number of days of inactivity before a PR becomes stale
+  daysUntilStale: 60
+  # Comment to post when marking a PR as stale. Set to `false` to disable
+  markComment: >
+    This pull request has been marked stale because it has not seen activity
+    within two months. It will be closed within 14 days of being stale
+    unless there is new activity.
+
+  # Number of days of inactivity before a stale PR is closed
+  daysUntilClose: 14
+  # Comment to post when closing a stale issue. Set to `false` to disable
+  closeComment: >
+    This pull request has been closed due to continued inactivity. If you are
+    interested in finishing the proposed changes, then feel free to re-open
+    this pull request or open a new one.


### PR DESCRIPTION
A follow-up for https://github.com/strongloop/loopback-next/pull/6745

/cc @strongloop/loopback-maintainers