### PR TITLE
chore: fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,9 @@ services:
 
 matrix:
   include:
-    - node_js: "12"
+    - node_js: '12'
       os: osx
+      osx_image: xcode12.2
       # using the default script to build & run the tests
 
     - node_js: '12'


### PR DESCRIPTION
Signed-off-by: Diana Lau <dhmlau@ca.ibm.com>

The recent builds are building for OSX:
```
==> Installing gdal dependency: qt
Warning: Your Xcode (9.4.1) is outdated.
Please update to Xcode 10.1 (or delete it).
Xcode can be updated from the App Store.
Warning: A newer Command Line Tools release is available.
Update them from Software Update in the App Store or run:
  softwareupdate --all --install --force
If that doesn't show you an update run:
  sudo rm -rf /Library/Developer/CommandLineTools
  sudo xcode-select --install
Alternatively, manually download them from:
  https://developer.apple.com/download/more/.
No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
The build has been terminated

```

~I'm not sure if it's related to the outdated tools but I found [this thread on StackOverflow](https://stackoverflow.com/questions/15417619/how-do-you-update-xcode-on-osx-to-the-latest-version/56252014#56252014) to upgrade the tools by running `brew upgrade`.~
UPDATED:
It looks like the build issue can be fixed by using a more recent version of OSX: https://docs.travis-ci.com/user/reference/osx/.

@raymondfeng @mrmodise, probably need your help here because I'm just guessing this might help with the build failure. PTAL. Thanks!