### PR TITLE
ci: add appveyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,24 @@
+image: "Visual Studio 2017"
+environment:
+  matrix:
+    - nodejs_version: "12"
+
+services:
+  - mongodb
+
+install:
+  # Install the Redis
+  - nuget install redis-64 -excludeversion
+  - redis-64\tools\redis-server.exe --service-install
+  - redis-64\tools\redis-server.exe --service-start
+  - '@ECHO Redis Started'
+  - ps: Install-Product node $env:nodejs_version
+  - node --version
+  - npm --version
+  - npm install
+
+test_script:
+  - npm run test:ci
+
+build: off
+skip_branch_with_pr: true


### PR DESCRIPTION
I cross-checked with loopback-next repo and Appveyor is still being used. Adding it back for this repo too